### PR TITLE
added a filter bar to All Posts to filter by category #14

### DIFF
--- a/rare-team-2/src/components/Posts/AllPosts.js
+++ b/rare-team-2/src/components/Posts/AllPosts.js
@@ -2,48 +2,77 @@ import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { getAllPostsWithAuthorAndCategory } from "../../services/postServices.js";
 import { deletePost } from "../../services/postServices.js";
+import { getAllCategories } from "../../services/categoryServices.js";
+import { PostFilterBar } from "./PostFilterBar.js";
 
 export const AllPosts = ({ currentUser }) => {
   const [allPosts, setAllPosts] = useState([]);
+  const [categories, setCategories] = useState([]);
+  const [filteredPosts, setFilteredPosts] = useState([]);
+  const [showChosenCategoryOnly, setChosenCategoryOnly] = useState(0);
 
   useEffect(() => {
     getAndSetPosts();
   }, []);
 
-  const getAndSetPosts = () => { 
-      getAllPostsWithAuthorAndCategory().then((posts) => {
-        setAllPosts(posts);
-      });
-    }
-
-    const handleDeletePost = (postId) => {
-      deletePost(postId).then(() => {
-          // Once the post is deleted, fetch and set the updated list of posts
-          getAndSetPosts();
-      });
+  const getAndSetPosts = () => {
+    getAllPostsWithAuthorAndCategory().then((posts) => {
+      setAllPosts(posts);
+    });
   };
 
-   
-  
+  const getAndSetCategories = () => {
+    getAllCategories().then(setCategories);
+  };
+
+  useEffect(() => {
+    getAndSetCategories();
+  }, []);
+
+  useEffect(() => {
+    if (showChosenCategoryOnly === "0") {
+      setFilteredPosts(allPosts);
+    } else if (showChosenCategoryOnly) {
+      const filtered = allPosts.filter(
+        (post) => post.category.category_id === parseInt(showChosenCategoryOnly)
+      );
+      setFilteredPosts(filtered);
+    } else {
+      setFilteredPosts(allPosts);
+    }
+  }, [allPosts, showChosenCategoryOnly]);
+
+  const handleDeletePost = (postId) => {
+    deletePost(postId).then(() => {
+      // Once the post is deleted, fetch and set the updated list of posts
+      getAndSetPosts();
+    });
+  };
 
   return (
-    <div>
-             {allPosts.map((post) => (
-            <Link to={`/myposts/${post?.id}`}>
-          <div key={post.id}>
-            <div>{post.title}</div>
-            <div>{post.author}</div>
-            <div>{post.category}</div>
-          </div>
-          <button onClick={() => handleDeletePost(post.id)}>Delete Post</button>
-            </Link>
-        
-        ))
-      }
+    <section className="post-list">
+      <PostFilterBar
+        setChosenCategoryOnly={setChosenCategoryOnly}
+        categories={categories}
+      />
+      <div>
+        {filteredPosts.map((post) => (
+          <Link key={post.id} to={`/myposts/${post?.id}`}>
+            <div>
+              <div>{post.title}</div>
+              <div>{post.author}</div>
+              <div>{post.category.category}</div>
+            </div>
+            <button onClick={() => handleDeletePost(post.id)}>
+              Delete Post
+            </button>
+          </Link>
+        ))}
 
-      <Link to="/newpost">
-     <button>New Post!</button> 
-      </Link>
-    </div>
+        <Link to="/newpost">
+          <button>New Post!</button>
+        </Link>
+      </div>
+    </section>
   );
 };

--- a/rare-team-2/src/components/Posts/PostFilterBar.js
+++ b/rare-team-2/src/components/Posts/PostFilterBar.js
@@ -1,0 +1,21 @@
+export const PostFilterBar = ({ categories, setChosenCategoryOnly }) => {
+  return (
+    <div className="filter-bar">
+      <select
+        className="category-dropdown"
+        onChange={(e) => {
+          setChosenCategoryOnly(e.target.value);
+        }}
+      >
+        <option value="0">Filter by category</option>
+        {categories.map((category) => {
+          return (
+            <option key={category.id} value={category.id}>
+              {category.label}
+            </option>
+          );
+        })}
+      </select>
+    </div>
+  );
+};

--- a/rare-team-2/src/components/comments/CommentList.js
+++ b/rare-team-2/src/components/comments/CommentList.js
@@ -20,7 +20,7 @@ export const CommentList = ({ postId }) => {
       <div className="comments">
         {comments.map((comment) => {
           return (
-            <section className="comment">
+            <section key={comment.id} className="comment">
               <div className="comment-card">
                 <p>{comment.created_on}</p>
                 <p>{comment.user}:</p>


### PR DESCRIPTION
Added a filter bar component to the All Posts page to only show posts based on the category selected from the drop down menu.
The page now includes 3 more states - categories, filtered posts, and chosen category.
The HTML is now derived from the filteredPosts state, the initial render sets filteredPosts to allPosts, showing all of the posts.
If a category is chosen from the drop-down menu, the chosen category state is set and all the posts are filtered to only include posts with a category_id that matches the chosen category state, which is set to the filteredPosts state. The list should now reflect the filtered posts.

TESTING:

1. Navigate to All Posts http://localhost:3000/allposts
2. Check to see if all posts are shown
3. Click the drop down menu and select a category
4. Verify if the displayed list has changed and that the category name on the post(s) matches the drop-down selection.
5. If the post list filters properly, everything works as intended.

Closes #14 